### PR TITLE
Add find_library() for librt.

### DIFF
--- a/backup/CMakeLists.txt
+++ b/backup/CMakeLists.txt
@@ -44,7 +44,11 @@ set(BACKUP_COMMUNITY_SOURCES
         backup_community.cc)
 
 add_library(HotBackupCommunity SHARED ${BACKUP_COMMUNITY_SOURCES})
-target_link_libraries(HotBackupCommunity LINK_PUBLIC rt)
+find_library(rt_LIBRARY NAMES rt)
+if (rt_LIBRARY)
+  target_link_libraries(HotBackupCommunity LINK_PUBLIC rt)
+endif ()
+
 
 # If for some reason we go back to static libraries, we'll need these two:
 # set_target_properties(HotBackupCommunity PROPERTIES POSITION_INDEPENDENT_CODE ON)


### PR DESCRIPTION
Librt is not found on OSX.
For this reason, the following toku_backup bundled source can not build on OSX.

http://www.tokutek.com/resources/support/gadownloads/
